### PR TITLE
Fix mobile player hardware back behavior

### DIFF
--- a/apps/mobile/app/player.tsx
+++ b/apps/mobile/app/player.tsx
@@ -11,11 +11,12 @@ import { Slider } from "@miblanchard/react-native-slider";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getMvByTrackId, plusGetMe, toggleTrackLike, toggleTrackUnLike } from "@soundx/services";
 import { useRouter } from "expo-router";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Animated,
   Alert,
+  BackHandler,
   Dimensions,
   FlatList,
   Image,
@@ -209,6 +210,25 @@ export function PlayerDetailView({
   const [lyricFontSize, setLyricFontSize] = useState(16);
   const [controlsBottomOffset, setControlsBottomOffset] = useState(0);
   const lineLayouts = useRef<{ [key: number]: any }>({});
+
+  const closePlayer = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)");
+    }
+  }, [router]);
+
+  useEffect(() => {
+    if (embedded) return;
+
+    const backHandler = BackHandler.addEventListener("hardwareBackPress", () => {
+      closePlayer();
+      return true;
+    });
+
+    return () => backHandler.remove();
+  }, [embedded, closePlayer]);
 
   useEffect(() => {
     const loadVipStatus = async () => {
@@ -609,13 +629,7 @@ export function PlayerDetailView({
         <Text style={{ color: colors.text }}>No track playing</Text>
         {!embedded && (
           <TouchableOpacity
-            onPress={() => {
-              if (router.canGoBack()) {
-                router.back();
-              } else {
-                router.replace("/(tabs)");
-              }
-            }}
+            onPress={closePlayer}
           >
             <Text style={{ color: colors.primary, marginTop: 20 }}>Go Back</Text>
           </TouchableOpacity>
@@ -949,13 +963,7 @@ export function PlayerDetailView({
             <View style={styles.landscapeBackBtn}>
               {!embedded && (
                 <TouchableOpacity
-                  onPress={() => {
-                    if (router.canGoBack()) {
-                      router.back();
-                    } else {
-                      router.replace("/(tabs)");
-                    }
-                  }}
+                  onPress={closePlayer}
                   style={styles.landscapeBackBtn}
                 >
                   <Ionicons name="chevron-down" size={30} color={colors.text} />
@@ -1076,13 +1084,7 @@ export function PlayerDetailView({
       {!embedded && (
         <View style={[styles.header, { top }]}>
           <TouchableOpacity
-            onPress={() => {
-              if (router.canGoBack()) {
-                router.back();
-              } else {
-                router.replace("/(tabs)");
-              }
-            }}
+            onPress={closePlayer}
             style={styles.headerButton}
           >
             <Ionicons name="chevron-down" size={30} color={colors.text} />


### PR DESCRIPTION
### Motivation
- On Android the system/hardware back button was causing the app to exit when the user was on a tab root (首页/声仓/个人) even if the player detail view was open, instead of closing the player first. 
- The goal is to ensure the back action closes the player detail view when the player is presented (non-embedded), and only then allow a subsequent back to exit the app.

### Description
- Imported `BackHandler` and added a `closePlayer` helper (wrapped with `useCallback`) in `apps/mobile/app/player.tsx` to centralize the logic that closes the player by calling `router.back()` or falling back to `router.replace("/(tabs)")`.
- Registered a `hardwareBackPress` listener when the player is opened in non-embedded mode to call `closePlayer()` and stop propagation to the tab-root exit handler.
- Replaced inline `router.back()`/`router.replace("/(tabs)")` usages in empty-player, landscape back button, and header chevron handlers to reuse `closePlayer()` for consistent behavior.
- All changes are contained in `apps/mobile/app/player.tsx` and make the player back behavior consistent across states.

### Testing
- Ran `pnpm --filter mobile exec eslint app/player.tsx`, which completed successfully (the file still has pre-existing warnings but no new errors introduced by this change).
- Ran `pnpm --filter mobile lint`, which failed due to pre-existing workspace lint/type resolution issues (unresolved `@soundx/*` imports and other unrelated warnings/errors) and not caused by this change.
- Ran `pnpm --filter mobile exec tsc --noEmit`, which failed due to existing TypeScript errors across the mobile/workspace packages and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9772c4388321945f767efbe3234d)