### PR TITLE
Gate TTS and member-only features behind Plus membership checks (desktop & mobile)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -68,7 +68,7 @@ const AppContent = () => {
   const { mode } = useTheme();
   const themeConfig = getThemeConfig(mode);
   const [messageApi, contextHolder] = message.useMessage();
-  const { token, user, plusToken } = useAuthStore();
+  const { token, user } = useAuthStore();
 
   const { checkUpdate, updateInfo, cancelUpdate } = useCheckUpdate();
 
@@ -163,7 +163,6 @@ const AppContent = () => {
   // We can handle this via Routes structure.
 
   const isAuthenticated = !!token;
-  const isMemberAuthenticated = !!plusToken;
 
   return (
     <ConfigProvider theme={themeConfig} locale={zhCN}>
@@ -174,13 +173,7 @@ const AppContent = () => {
             <Routes>
               <Route path="/member-login" element={<MemberLogin />} />
 
-              {!isMemberAuthenticated ? (
-                <Route
-                  path="*"
-                  element={<Navigate to="/member-login" replace />}
-                />
-              ) : (
-                <>
+              <>
                   <Route path="/source-manage" element={<SourceManage />} />
                   <Route path="/login" element={<Login />} />
                   <Route path="/forgot-password" element={<ForgotPassword />} />

--- a/apps/desktop/src/components/Header/index.tsx
+++ b/apps/desktop/src/components/Header/index.tsx
@@ -900,6 +900,19 @@ const Header: React.FC = () => {
               className={styles.actionIcon}
               style={actionIconStyle}
               onClick={() => {
+                const plusToken = localStorage.getItem("plus_token");
+                if (!plusToken) {
+                  messageApi.info(t("common.loginFirst"));
+                  navigate("/member-login");
+                  return;
+                }
+
+                if (!isPlusVip) {
+                  messageApi.info(t("common.vipOnly"));
+                  navigate("/member-benefits");
+                  return;
+                }
+
                 trackEvent({
                   feature: "tts",
                   eventName: "tts_task_list_open",

--- a/apps/desktop/src/pages/TTS/CreateTask/index.tsx
+++ b/apps/desktop/src/pages/TTS/CreateTask/index.tsx
@@ -15,6 +15,7 @@ import {
   getTtsVoices,
   identifyTtsBatch,
   uploadTtsFile,
+  plusGetMe,
 } from "@soundx/services";
 import {
   Button,
@@ -55,6 +56,26 @@ const CreateTask: React.FC = () => {
   const [view, setView] = useState<"select" | "review">("select");
   const [reviewData, setReviewData] = useState<ReviewItem[]>([]);
 
+  const ensureVipAccess = async () => {
+    const plusToken = localStorage.getItem("plus_token");
+    const plusUserId = localStorage.getItem("plus_user_id");
+    if (!plusToken || !plusUserId) {
+      message.info("请先登录会员账号");
+      navigate("/member-login", { replace: true });
+      return false;
+    }
+    let id:any = plusUserId;
+    try { id = JSON.parse(plusUserId); } catch {}
+    const res = await plusGetMe(id);
+    const tier = res?.data?.data?.vipTier;
+    if (!tier || tier === "NONE") {
+      message.info("该功能需要开通会员");
+      navigate("/member-benefits", { replace: true });
+      return false;
+    }
+    return true;
+  };
+
   const fetchVoices = async () => {
     try {
       const data = await getTtsVoices();
@@ -81,8 +102,7 @@ const CreateTask: React.FC = () => {
   };
 
   useEffect(() => {
-    fetchVoices();
-    fetchLocalFiles();
+    ensureVipAccess().then((ok)=>{ if (ok) { fetchVoices(); fetchLocalFiles(); } });
   }, []);
 
   const handlePreview = async (voice: string) => {

--- a/apps/desktop/src/pages/TTS/TaskList/index.tsx
+++ b/apps/desktop/src/pages/TTS/TaskList/index.tsx
@@ -5,6 +5,7 @@ import {
     getTtsTasks,
     pauseTtsTask,
     resumeTtsTask,
+    plusGetMe,
 } from "@soundx/services";
 import {
     Button,
@@ -14,7 +15,7 @@ import {
     Space,
     Table,
     Tag,
-    Typography,
+    Typography
 } from "antd";
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -29,6 +30,26 @@ const TaskList: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [filterStatus, setFilterStatus] = useState<string>("all");
   const navigate = useNavigate();
+
+  const ensureVipAccess = async () => {
+    const plusToken = localStorage.getItem("plus_token");
+    const plusUserId = localStorage.getItem("plus_user_id");
+    if (!plusToken || !plusUserId) {
+      alert("请先登录会员账号");
+      navigate("/member-login", { replace: true });
+      return false;
+    }
+    let id:any = plusUserId;
+    try { id = JSON.parse(plusUserId); } catch {}
+    const res = await plusGetMe(id);
+    const tier = res?.data?.data?.vipTier;
+    if (!tier || tier === "NONE") {
+      alert("该功能需要开通会员");
+      navigate("/member-benefits", { replace: true });
+      return false;
+    }
+    return true;
+  };
 
   const fetchTasks = async (showLoading = true) => {
     if (showLoading) setLoading(true);
@@ -73,7 +94,7 @@ const TaskList: React.FC = () => {
   };
 
   useEffect(() => {
-    fetchTasks();
+    ensureVipAccess().then((ok)=>{ if (ok) fetchTasks(); });
     const timer = setInterval(() => fetchTasks(false), 5000); // 后台静默刷新
     return () => clearInterval(timer);
   }, []);

--- a/apps/mobile/app/(tabs)/personal.tsx
+++ b/apps/mobile/app/(tabs)/personal.tsx
@@ -203,6 +203,15 @@ export default function PersonalScreen() {
       return;
     }
 
+    const plusToken = await AsyncStorage.getItem("plus_token");
+    if (!plusToken) {
+      Alert.alert(t("common.memberFeature"), t("common.loginFirst"), [
+        { text: t("common.cancel"), style: "cancel" },
+        { text: t("personalPage.memberLogin"), onPress: () => router.push("/member-login" as any) },
+      ]);
+      return;
+    }
+
     if (isPlusVip) {
       trackEvent({
         feature: "scan_login",
@@ -468,6 +477,15 @@ export default function PersonalScreen() {
       userId: user?.id ? String(user.id) : undefined,
       deviceId: device?.id ? String(device.id) : undefined,
     });
+
+    const plusToken = await AsyncStorage.getItem("plus_token");
+    if (!plusToken) {
+      Alert.alert(t("common.memberFeature"), t("common.loginFirst"), [
+        { text: t("common.cancel"), style: "cancel" },
+        { text: t("personalPage.memberLogin"), onPress: () => router.push("/member-login" as any) },
+      ]);
+      return;
+    }
 
     if (isPlusVip) {
       trackEvent({
@@ -964,7 +982,16 @@ export default function PersonalScreen() {
                     }
                     const plusToken = await AsyncStorage.getItem("plus_token");
                     if (plusToken) {
-                        if (isPlusVip) {
+                        const plusToken = await AsyncStorage.getItem("plus_token");
+    if (!plusToken) {
+      Alert.alert(t("common.memberFeature"), t("common.loginFirst"), [
+        { text: t("common.cancel"), style: "cancel" },
+        { text: t("personalPage.memberLogin"), onPress: () => router.push("/member-login" as any) },
+      ]);
+      return;
+    }
+
+    if (isPlusVip) {
                             router.push("/member-detail");
                         } else {
                             router.push("/member-benefits" as any);

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -93,14 +93,12 @@ function RootLayoutNav() {
       segmentName === "playback-quality" ||
       segmentName === "mv";
 
-    if (!plusToken && inAuthGroup) {
-      router.replace("/member-login");
-    } else if (plusToken && !token && inAuthGroup) {
+    if (!token && inAuthGroup) {
       router.replace("/login");
-    } else if (token && plusToken && !inAuthGroup && !isDetailPage) {
+    } else if (token && !inAuthGroup && !isDetailPage) {
       router.replace("/(tabs)");
     }
-  }, [token, plusToken, segments, isLoading]);
+  }, [token, segments, isLoading]);
 
   useEffect(() => {
     if (!url) return;

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -209,15 +209,25 @@ export default function SettingsScreen() {
   );
 
   const handleToggleCarMode = async (val: boolean) => {
-    if (val && !isVip) {
-      Alert.alert(t("settings.vipOnly"), t("settings.carModeVipOnly"), [
-        { text: t("common.ok") },
-        {
-          text: t("settings.goToMemberPage"),
-          onPress: () => router.push("/member-benefits" as any),
-        },
-      ]);
-      return;
+    if (val) {
+      const currentPlusToken = await AsyncStorage.getItem("plus_token");
+      if (!currentPlusToken) {
+        Alert.alert(t("common.memberFeature"), t("common.loginFirst"), [
+          { text: t("common.cancel"), style: "cancel" },
+          { text: t("settings.goToMemberPage"), onPress: () => router.push("/member-login" as any) },
+        ]);
+        return;
+      }
+      if (!isVip) {
+        Alert.alert(t("settings.vipOnly"), t("settings.carModeVipOnly"), [
+          { text: t("common.ok") },
+          {
+            text: t("settings.goToMemberPage"),
+            onPress: () => router.push("/member-benefits" as any),
+          },
+        ]);
+        return;
+      }
     }
     await updateSetting("carModeEnabled", val);
     await updateSetting("carLayoutMode", val);
@@ -233,15 +243,25 @@ export default function SettingsScreen() {
   };
 
   const handleToggleVoiceAssistant = async (val: boolean) => {
-    if (val && !isVip) {
-      Alert.alert(t("settings.vipOnly"), t("settings.voiceAssistantVipOnly"), [
-        { text: t("common.ok") },
-        {
-          text: t("settings.goToMemberPage"),
-          onPress: () => router.push("/member-benefits" as any),
-        },
-      ]);
-      return;
+    if (val) {
+      const currentPlusToken = await AsyncStorage.getItem("plus_token");
+      if (!currentPlusToken) {
+        Alert.alert(t("common.memberFeature"), t("common.loginFirst"), [
+          { text: t("common.cancel"), style: "cancel" },
+          { text: t("settings.goToMemberPage"), onPress: () => router.push("/member-login" as any) },
+        ]);
+        return;
+      }
+      if (!isVip) {
+        Alert.alert(t("settings.vipOnly"), t("settings.voiceAssistantVipOnly"), [
+          { text: t("common.ok") },
+          {
+            text: t("settings.goToMemberPage"),
+            onPress: () => router.push("/member-benefits" as any),
+          },
+        ]);
+        return;
+      }
     }
     await updateSetting("voiceAssistantEnabled", val);
     trackEvent({

--- a/apps/mobile/app/tts/create.tsx
+++ b/apps/mobile/app/tts/create.tsx
@@ -8,10 +8,12 @@ import {
   TtsFileItem,
   TtsReviewItem,
   TtsVoice,
+  plusGetMe,
 } from "@soundx/services";
 import { Audio } from "expo-av";
 import { useRouter } from "expo-router";
-import React, { useEffect, useRef, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -40,6 +42,30 @@ export default function TtsCreateTaskScreen() {
   const [reviewData, setReviewData] = useState<TtsReviewItem[]>([]);
   const [previewLoading, setPreviewLoading] = useState<string | null>(null);
 
+  const ensureVipAccess = useCallback(async () => {
+    const plusToken = await AsyncStorage.getItem("plus_token");
+    const plusUserId = await AsyncStorage.getItem("plus_user_id");
+    if (!plusToken || !plusUserId) {
+      Alert.alert("提示", "请先登录会员账号", [
+        { text: "取消", style: "cancel" },
+        { text: "去登录", onPress: () => router.replace("/member-login" as any) },
+      ]);
+      return false;
+    }
+    let id:any = plusUserId;
+    try { id = JSON.parse(plusUserId); } catch {}
+    const res = await plusGetMe(id);
+    const tier = res?.data?.data?.vipTier;
+    if (!tier || tier === "NONE") {
+      Alert.alert("提示", "该功能需要开通会员", [
+        { text: "取消", style: "cancel" },
+        { text: "去开通", onPress: () => router.replace("/member-benefits" as any) },
+      ]);
+      return false;
+    }
+    return true;
+  }, [router]);
+
   const soundRef = useRef<Audio.Sound | null>(null);
 
   useEffect(() => {
@@ -50,8 +76,7 @@ export default function TtsCreateTaskScreen() {
       shouldDuckAndroid: true,
       playThroughEarpieceAndroid: false,
     });
-    fetchVoices();
-    fetchLocalFiles();
+    ensureVipAccess().then((ok)=>{ if (ok) { fetchVoices(); fetchLocalFiles(); } });
     return () => {
       if (soundRef.current) {
         soundRef.current.unloadAsync();

--- a/apps/mobile/app/tts/tasks.tsx
+++ b/apps/mobile/app/tts/tasks.tsx
@@ -5,8 +5,10 @@ import {
   pauseTtsTask,
   resumeTtsTask,
   TtsTask,
+  plusGetMe,
 } from "@soundx/services";
 import { useRouter } from "expo-router";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import React, { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
@@ -33,6 +35,30 @@ export default function TtsTaskListScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
 
+  const ensureVipAccess = useCallback(async () => {
+    const plusToken = await AsyncStorage.getItem("plus_token");
+    const plusUserId = await AsyncStorage.getItem("plus_user_id");
+    if (!plusToken || !plusUserId) {
+      Alert.alert("提示", "请先登录会员账号", [
+        { text: "取消", style: "cancel" },
+        { text: "去登录", onPress: () => router.replace("/member-login" as any) },
+      ]);
+      return false;
+    }
+    let id:any = plusUserId;
+    try { id = JSON.parse(plusUserId); } catch {}
+    const res = await plusGetMe(id);
+    const tier = res?.data?.data?.vipTier;
+    if (!tier || tier === "NONE") {
+      Alert.alert("提示", "该功能需要开通会员", [
+        { text: "取消", style: "cancel" },
+        { text: "去开通", onPress: () => router.replace("/member-benefits" as any) },
+      ]);
+      return false;
+    }
+    return true;
+  }, [router]);
+
   const fetchTasks = useCallback(async (showLoading = false) => {
     if (showLoading) setLoading(true);
     try {
@@ -47,7 +73,7 @@ export default function TtsTaskListScreen() {
   }, []);
 
   useEffect(() => {
-    fetchTasks(true);
+    ensureVipAccess().then((ok)=>{ if (ok) fetchTasks(true); else setLoading(false); });
     const timer = setInterval(() => fetchTasks(false), 5000);
     return () => clearInterval(timer);
   }, [fetchTasks]);


### PR DESCRIPTION
### Motivation
- Prevent non-members from accessing TTS and other Plus-only features by verifying membership status at the UI entry points. 
- Use the backend `plusGetMe` check to confirm the user's `vipTier` rather than relying solely on local tokens. 
- Simplify some routing logic to avoid coupling navigation to a `plusToken` flag stored in the auth store.

### Description
- Added runtime membership checks that read `plus_token` and `plus_user_id` from `localStorage` (desktop) or `AsyncStorage` (mobile) and call `plusGetMe` from `@soundx/services` to validate `vipTier`, implemented as `ensureVipAccess` helpers in multiple TTS components. 
- Gated entry points and actions to show a message/alert and redirect to `"/member-login"` or `"/member-benefits"` when the user is not logged in as a Plus member; updated desktop header TTS click handler to enforce these checks and show `messageApi` feedback. 
- Applied checks to desktop `CreateTask` and `TaskList` pages and mobile `tts/create`, `tts/tasks`, personal screen, and settings toggles for `carMode` and `voiceAssistant` to require login or VIP status before enabling features. 
- Updated `App.tsx` and mobile layout routing to remove reliance on `plusToken` from the auth store and simplified some auth-routing conditions while keeping TTS/member flows gated at the component level. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd31a2860832180eb89b0842e3f1e)