### PR TITLE
Show WebDAV test toast on desktop and cache mobile library tabs to avoid skeleton flashes

### DIFF
--- a/apps/desktop/src/pages/Settings/WebDavSourcesSettings.tsx
+++ b/apps/desktop/src/pages/Settings/WebDavSourcesSettings.tsx
@@ -4,7 +4,6 @@ import {
   Empty,
   Form,
   Input,
-  message,
   Popconfirm,
   Progress,
   Space,
@@ -24,6 +23,7 @@ import {
 } from "@soundx/services";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useMessage } from "../../context/MessageContext";
 import styles from "./index.module.less";
 
 const { Text, Paragraph } = Typography;
@@ -64,6 +64,7 @@ const emptyPaths = () => ({ MUSIC: "", AUDIOBOOK: "", MV: "" });
 
 const WebDavSourcesSettings: React.FC = () => {
   const { t } = useTranslation();
+  const message = useMessage();
   const [sources, setSources] = useState<WebDavSource[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -32,7 +32,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { initBaseURL } from "@/src/https";
 import { Image as ExpoImage } from "expo-image";
 import { CachedImage } from "../../src/components/CachedImage";
-import SkeletonBlock from "../../src/components/SkeletonBlock";
 import { useAuth } from "../../src/context/AuthContext";
 import { useSettings } from "../../src/context/SettingsContext";
 import { useTheme } from "../../src/context/ThemeContext";
@@ -45,91 +44,6 @@ interface Section {
   title: string;
   data: any[];
   type: "artist" | "album" | "track";
-}
-
-function HomeSkeleton({ insets }: { insets: { top: number } }) {
-  const { colors } = useTheme();
-  return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
-        <View style={styles.header}>
-          <SkeletonBlock width={72} height={30} borderRadius={10} />
-          <View style={styles.headerRight}>
-            <SkeletonBlock width={36} height={36} borderRadius={18} style={{ marginRight: 10 }} />
-            <SkeletonBlock width={36} height={36} borderRadius={18} />
-          </View>
-        </View>
-
-        <View style={styles.searchBar}>
-          <SkeletonBlock width={180} height={18} borderRadius={9} />
-        </View>
-
-        {Array.from({ length: 3 }).map((_, sectionIndex) => (
-          <View key={`home-skeleton-section-${sectionIndex}`}>
-            <View style={styles.sectionHeader}>
-              <SkeletonBlock width={96} height={26} borderRadius={10} />
-              <SkeletonBlock width={20} height={20} borderRadius={10} />
-            </View>
-
-            {sectionIndex === 2 ? (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.horizontalList}
-              >
-                {Array.from({ length: 3 }).map((__, columnIndex) => (
-                  <View key={`track-skeleton-column-${columnIndex}`} style={styles.trackColumn}>
-                    {Array.from({ length: 2 }).map((___, rowIndex) => (
-                      <View key={`track-skeleton-${columnIndex}-${rowIndex}`} style={styles.trackCard}>
-                        <SkeletonBlock width={50} height={50} borderRadius={4} />
-                        <View style={styles.trackInfo}>
-                          <SkeletonBlock width={140} height={14} borderRadius={7} style={{ marginBottom: 6 }} />
-                          <SkeletonBlock width={96} height={12} borderRadius={6} />
-                        </View>
-                        <View style={styles.trackActions}>
-                          <SkeletonBlock width={18} height={18} borderRadius={9} style={{ marginBottom: 10 }} />
-                          <SkeletonBlock width={18} height={18} borderRadius={9} />
-                        </View>
-                      </View>
-                    ))}
-                  </View>
-                ))}
-              </ScrollView>
-            ) : (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.horizontalList}
-              >
-                {Array.from({ length: 4 }).map((__, itemIndex) => (
-                  <View
-                    key={`card-skeleton-${sectionIndex}-${itemIndex}`}
-                    style={sectionIndex === 0 ? styles.artistCard : styles.albumCard}
-                  >
-                    <SkeletonBlock
-                      width={sectionIndex === 0 ? 100 : 120}
-                      height={sectionIndex === 0 ? 100 : 120}
-                      borderRadius={sectionIndex === 0 ? 50 : 10}
-                      style={{ marginBottom: 8 }}
-                    />
-                    <SkeletonBlock width={sectionIndex === 0 ? 76 : 92} height={12} borderRadius={6} style={{ marginBottom: 6 }} />
-                    {sectionIndex !== 0 ? (
-                      <SkeletonBlock width={68} height={12} borderRadius={6} />
-                    ) : null}
-                  </View>
-                ))}
-              </ScrollView>
-            )}
-          </View>
-        ))}
-
-        <View style={styles.reorderButton}>
-          <SkeletonBlock width={20} height={20} borderRadius={10} />
-          <SkeletonBlock width={72} height={16} borderRadius={8} />
-        </View>
-      </ScrollView>
-    </View>
-  );
 }
 
 export default function HomeScreen() {
@@ -150,7 +64,6 @@ export default function HomeScreen() {
   const router = useRouter();
 
   const [sections, setSections] = useState<Section[]>([]);
-  const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
   const radioAnim = React.useRef(new Animated.Value(0)).current;
@@ -232,8 +145,6 @@ export default function HomeScreen() {
   const loadData = useCallback(
     async (forceRefresh = false) => {
       try {
-        if (!forceRefresh) setLoading(true);
-
         // Try cache first if not refreshing
         if (!forceRefresh) {
           const cachedSections = await cacheUtils.get<Section[]>(
@@ -265,7 +176,6 @@ export default function HomeScreen() {
               }
             }
             setSections(cachedSections);
-            setLoading(false);
             setRefreshing(false);
             return;
           }
@@ -351,7 +261,6 @@ export default function HomeScreen() {
       } catch (error) {
         console.error("Failed to load home data:", error);
       } finally {
-        setLoading(false);
         setRefreshing(false);
       }
     },
@@ -438,10 +347,6 @@ export default function HomeScreen() {
       console.error(`Failed to refresh section ${sectionId}:`, error);
     }
   };
-
-  if (loading && !refreshing) {
-    return <HomeSkeleton insets={insets} />;
-  }
 
   return (
     <View

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -38,6 +38,14 @@ const TARGET_WIDTH = 100; // Slightly smaller target for dense list
 const SONG_SKELETON_COUNT = 9;
 const GRID_SKELETON_COUNT = 12;
 
+const libraryTabCache = {
+  tracks: new Map<string, Track[]>(),
+  artists: new Map<string, Artist[]>(),
+  albums: new Map<string, Album[]>(),
+  collections: new Map<string, any[]>(),
+  mvs: new Map<string, any[]>(),
+};
+
 interface SongListProps {
   isSelectionMode: boolean;
   setIsSelectionMode: (value: boolean) => void;
@@ -59,8 +67,9 @@ const SongList = ({
   const { t } = useTranslation();
   const { mode } = usePlayMode();
   const { playTrackList } = usePlayer();
-  const [tracks, setTracks] = useState<Track[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = `${mode}_${heartbeatModeActive ? "heartbeat" : "normal"}`;
+  const [tracks, setTracks] = useState<Track[]>(() => libraryTabCache.tracks.get(cacheKey) || []);
+  const [loading, setLoading] = useState(() => !libraryTabCache.tracks.has(cacheKey));
   const [addToPlaylistVisible, setAddToPlaylistVisible] = useState(false);
   const flatListRef = useRef<FlatList<Track>>(null);
   const { currentTrack } = usePlayer();
@@ -86,12 +95,18 @@ const SongList = ({
   };
 
   useEffect(() => {
+    const cached = libraryTabCache.tracks.get(cacheKey);
+    if (cached) {
+      setTracks(cached);
+      setLoading(false);
+      return;
+    }
     loadTracks();
-  }, [mode, heartbeatModeActive]);
+  }, [cacheKey]);
 
   const loadTracks = async () => {
     try {
-      setLoading(true);
+      setLoading(tracks.length === 0);
       const res = await loadMoreTrack({
         pageSize: 2000,
         loadCount: 0,
@@ -104,11 +119,11 @@ const SongList = ({
         const mappedTracks = list.map((item: any) =>
           item.track ? item.track : item,
         );
-        setTracks(
-          heartbeatModeActive
-            ? mappedTracks
-            : mappedTracks.sort((a, b) => a.name.localeCompare(b.name)),
-        );
+        const nextTracks = heartbeatModeActive
+          ? mappedTracks
+          : mappedTracks.sort((a, b) => a.name.localeCompare(b.name));
+        libraryTabCache.tracks.set(cacheKey, nextTracks);
+        setTracks(nextTracks);
       }
     } catch (error) {
       console.error("Failed to load tracks:", error);
@@ -336,8 +351,9 @@ const ArtistList = ({
   const router = useRouter();
   const { mode } = usePlayMode();
   const { width } = useWindowDimensions();
-  const [artists, setArtists] = useState<Artist[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = `${mode}_${heartbeatModeActive ? "heartbeat" : "normal"}`;
+  const [artists, setArtists] = useState<Artist[]>(() => libraryTabCache.artists.get(cacheKey) || []);
+  const [loading, setLoading] = useState(() => !libraryTabCache.artists.has(cacheKey));
   const flatListRef = useRef<FlatList<Artist>>(null);
   const { currentTrack } = usePlayer();
 
@@ -371,12 +387,18 @@ const ArtistList = ({
   const itemWidth = (availableWidth - (numColumns - 1) * GAP) / numColumns;
 
   useEffect(() => {
+    const cached = libraryTabCache.artists.get(cacheKey);
+    if (cached) {
+      setArtists(cached);
+      setLoading(false);
+      return;
+    }
     loadArtists();
-  }, [mode, heartbeatModeActive]);
+  }, [cacheKey]);
 
   const loadArtists = async () => {
     try {
-      setLoading(true);
+      setLoading(artists.length === 0);
       const res = await getArtistList(
         1000,
         0,
@@ -386,11 +408,11 @@ const ArtistList = ({
 
       if (res.code === 200 && res.data) {
         const { list } = res.data;
-        setArtists(
-          heartbeatModeActive
-            ? list
-            : list.sort((a, b) => a.name.localeCompare(b.name)),
-        );
+        const nextArtists = heartbeatModeActive
+          ? list
+          : list.sort((a, b) => a.name.localeCompare(b.name));
+        libraryTabCache.artists.set(cacheKey, nextArtists);
+        setArtists(nextArtists);
       }
     } catch (error) {
       console.error("Failed to load artists:", error);
@@ -510,8 +532,9 @@ const AlbumList = ({
   const router = useRouter();
   const { mode } = usePlayMode();
   const { width } = useWindowDimensions();
-  const [albums, setAlbums] = useState<Album[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = `${mode}_${heartbeatModeActive ? "heartbeat" : "normal"}`;
+  const [albums, setAlbums] = useState<Album[]>(() => libraryTabCache.albums.get(cacheKey) || []);
+  const [loading, setLoading] = useState(() => !libraryTabCache.albums.has(cacheKey));
   const flatListRef = useRef<FlatList<Album>>(null);
   const { currentTrack } = usePlayer();
 
@@ -549,12 +572,18 @@ const AlbumList = ({
   const itemWidth = (availableWidth - (numColumns - 1) * GAP) / numColumns;
 
   useEffect(() => {
+    const cached = libraryTabCache.albums.get(cacheKey);
+    if (cached) {
+      setAlbums(cached);
+      setLoading(false);
+      return;
+    }
     loadAlbums();
-  }, [mode, heartbeatModeActive]);
+  }, [cacheKey]);
 
   const loadAlbums = async () => {
     try {
-      setLoading(true);
+      setLoading(albums.length === 0);
       const res = await loadMoreAlbum({
         pageSize: 1000,
         loadCount: 0,
@@ -564,11 +593,11 @@ const AlbumList = ({
 
       if (res.code === 200 && res.data) {
         const { list } = res.data;
-        setAlbums(
-          heartbeatModeActive
-            ? list
-            : list.sort((a, b) => a.name.localeCompare(b.name)),
-        );
+        const nextAlbums = heartbeatModeActive
+          ? list
+          : list.sort((a, b) => a.name.localeCompare(b.name));
+        libraryTabCache.albums.set(cacheKey, nextAlbums);
+        setAlbums(nextAlbums);
       }
     } catch (error) {
       console.error("Failed to load albums:", error);
@@ -709,8 +738,9 @@ const CollectionList = () => {
   const { mode } = usePlayMode();
   const { user } = useAuth();
   const { width } = useWindowDimensions();
-  const [collections, setCollections] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = user ? `${mode}_${user.id}` : `${mode}_anonymous`;
+  const [collections, setCollections] = useState<any[]>(() => libraryTabCache.collections.get(cacheKey) || []);
+  const [loading, setLoading] = useState(() => !libraryTabCache.collections.has(cacheKey));
 
   // Calculate columns dynamically
   const availableWidth = width - SCREEN_PADDING;
@@ -722,15 +752,22 @@ const CollectionList = () => {
 
   useEffect(() => {
     if (mode !== "AUDIOBOOK" || !user) return;
+    const cached = libraryTabCache.collections.get(cacheKey);
+    if (cached) {
+      setCollections(cached);
+      setLoading(false);
+      return;
+    }
     loadCollections();
-  }, [mode, user]);
+  }, [cacheKey, mode, user]);
 
   const loadCollections = async () => {
     if (!user) return;
     try {
-      setLoading(true);
+      setLoading(collections.length === 0);
       const res = await getCollections(user.id);
       if (res.code === 200 && res.data) {
+        libraryTabCache.collections.set(cacheKey, res.data);
         setCollections(res.data);
       }
     } catch (error) {
@@ -826,8 +863,9 @@ const MvList = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { width } = useWindowDimensions();
-  const [mvs, setMvs] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheKey = "all";
+  const [mvs, setMvs] = useState<any[]>(() => libraryTabCache.mvs.get(cacheKey) || []);
+  const [loading, setLoading] = useState(() => !libraryTabCache.mvs.has(cacheKey));
 
   // Calculate columns dynamically
   const availableWidth = width - SCREEN_PADDING;
@@ -838,14 +876,21 @@ const MvList = () => {
   const itemWidth = (availableWidth - (numColumns - 1) * GAP) / numColumns;
 
   useEffect(() => {
+    const cached = libraryTabCache.mvs.get(cacheKey);
+    if (cached) {
+      setMvs(cached);
+      setLoading(false);
+      return;
+    }
     loadMvs();
-  }, []);
+  }, [cacheKey]);
 
   const loadMvs = async () => {
     try {
-      setLoading(true);
+      setLoading(mvs.length === 0);
       const res = await getMvList(1000, 0);
       if (res?.list) {
+        libraryTabCache.mvs.set(cacheKey, res.list);
         setMvs(res.list);
       }
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Desktop WebDAV test was returning success but toasts didn't appear because the Ant Design `message` instance used by the app was not available in that component's context.  
- Mobile tab switching in the 声仓 (library) and Home pages caused frequent skeleton-screen flashes and reloading of already-fetched data, harming UX.  
- The goal is to reliably surface test-connection feedback on desktop and avoid unnecessary skeleton loading when switching tabs on mobile by reusing previously loaded data.

### Description
- Desktop: use the app-level `MessageContext` message instance via `useMessage()` in `apps/desktop/src/pages/Settings/WebDavSourcesSettings.tsx` so `message.success(...)` / `message.error(...)` display reliably inside the desktop UI.  
- Mobile (Home): remove the hard-coded Home skeleton render branch and related unconditional loading toggles in `apps/mobile/app/(tabs)/index.tsx` so cached sections remain visible while background refresh runs.  
- Mobile (Library): add an in-memory per-tab cache `libraryTabCache` and use cache keys (`mode` + `heartbeat` flag or user id where appropriate) in `apps/mobile/app/(tabs)/library.tsx` to initialize and short-circuit loading for `tracks`, `artists`, `albums`, `collections`, and `mvs`, and save loaded results into the cache to avoid re-fetch and skeleton flashes on tab switches.  
- Minor cleanup: remove unused local `SkeletonBlock` import from Home index and adjust loading state logic to depend on cache presence.

### Testing
- Ran targeted lint checks for the modified mobile files with `cd apps/mobile && npx eslint 'app/(tabs)/index.tsx' 'app/(tabs)/library.tsx'`, which completed and reported only existing project warnings (no new errors).  
- Ran targeted lint check for the modified desktop file with `cd apps/desktop && npx eslint src/pages/Settings/WebDavSourcesSettings.tsx`, which completed successfully.  
- Full mobile lint `pnpm --filter mobile lint` failed due to unrelated existing workspace lint/resolve errors elsewhere in the repo, and full web build `pnpm --filter sound-x build:web` failed due to unrelated workspace TypeScript/module resolution errors; these failures are pre-existing and not caused by the targeted changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4477f94f6c8321b441bb1e5af29cf4)