### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,4 +241,4 @@ docker-compose up
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mmdctjj/AudioDock&type=Date)](https://star-history.com/#mmdctjj/AudioDock&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mmdctjj/AudioDock&type=Date)](https://star-history.dera.page/#mmdctjj/AudioDock&type=Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已失效，无法正常加载。

本 MR 将图表切换至不受限的新数据源，恢复 Star History 图表的正常显示。