### PR TITLE
fix(harmony): 同步桌面卡片播放状态

### DIFF
--- a/apps/harmony/products/entry/src/main/ets/formability/EntryFormAbility.ets
+++ b/apps/harmony/products/entry/src/main/ets/formability/EntryFormAbility.ets
@@ -307,8 +307,9 @@ export default class EntryFormAbility extends FormExtensionAbility {
       }
       case WidgetKind.PLAYLIST: {
         const pl = await kvStore.getJSON<PlaylistsSnapshot>(WIDGET_KV_KEYS.playlists);
-        const v = pl ?? { items: [], updatedAt: 0 };
+        const v = pl ?? { items: [], isPlaying: false, updatedAt: 0 };
         out['items'] = v.items;
+        out['isPlaying'] = v.isPlaying;
         out['updatedAt'] = v.updatedAt;
         break;
       }
@@ -322,8 +323,9 @@ export default class EntryFormAbility extends FormExtensionAbility {
       }
       case WidgetKind.LATEST: {
         const lt = await kvStore.getJSON<LatestSnapshot>(WIDGET_KV_KEYS.latest);
-        const v = lt ?? { items: [], updatedAt: 0 };
+        const v = lt ?? { items: [], isPlaying: false, updatedAt: 0 };
         out['items'] = v.items;
+        out['isPlaying'] = v.isPlaying;
         out['updatedAt'] = v.updatedAt;
         break;
       }

--- a/apps/harmony/products/entry/src/main/ets/models/WidgetData.ets
+++ b/apps/harmony/products/entry/src/main/ets/models/WidgetData.ets
@@ -47,6 +47,8 @@ export interface PlaylistSnapshotItem {
 
 export interface PlaylistsSnapshot {
   items: PlaylistSnapshotItem[];
+  /** Header play/pause control mirrors the shared now-playing state. */
+  isPlaying: boolean;
   updatedAt: number;
 }
 
@@ -75,6 +77,8 @@ export interface LatestTrackDto {
 
 export interface LatestSnapshot {
   items: LatestTrackDto[];
+  /** Header play/pause control mirrors the shared now-playing state. */
+  isPlaying: boolean;
   updatedAt: number;
 }
 

--- a/apps/harmony/products/entry/src/main/ets/services/WidgetBridge.ets
+++ b/apps/harmony/products/entry/src/main/ets/services/WidgetBridge.ets
@@ -211,6 +211,8 @@ class WidgetBridgeImpl {
         updatedAt: Date.now(),
       };
       await this.writeAndPushNowPlaying(empty);
+      await this.syncHistoryNowPlaying(empty);
+      await this.syncListCardPlaybackState(false);
       return;
     }
     const isLiked = cur.id ? await likesHistory.isTrackLiked(cur.id) : false;
@@ -226,6 +228,8 @@ class WidgetBridgeImpl {
       updatedAt: Date.now(),
     };
     await this.writeAndPushNowPlaying(snap);
+    await this.syncHistoryNowPlaying(snap);
+    await this.syncListCardPlaybackState(snap.isPlaying);
   }
 
   // ─── 启动时拉取：VIP、歌单、历史、上新 ────────────────────────────────
@@ -268,8 +272,14 @@ class WidgetBridgeImpl {
           trackCount: typeof it.trackCount === 'number' ? it.trackCount : 0,
         });
       }
-      const snap: PlaylistsSnapshot = { items, updatedAt: Date.now() };
+      const store = await this.getPlayerStore();
+      const snap: PlaylistsSnapshot = {
+        items,
+        isPlaying: store ? store.view().isPlaying : false,
+        updatedAt: Date.now(),
+      };
       await kvStore.setJSON<PlaylistsSnapshot>(WIDGET_KV_KEYS.playlists, snap);
+      await this.updateForms(WidgetKind.PLAYLIST, snap);
       Logger.i(TAG, `syncPlaylists count=${items.length}`);
     } catch (e) {
       Logger.w(TAG, `syncPlaylists: ${String(e)}`);
@@ -308,6 +318,7 @@ class WidgetBridgeImpl {
       } : null;
       const snap: HistorySnapshot = { nowPlaying: np, items, updatedAt: Date.now() };
       await kvStore.setJSON<HistorySnapshot>(WIDGET_KV_KEYS.history, snap);
+      await this.updateForms(WidgetKind.HISTORY, snap);
       Logger.i(TAG, `syncHistory count=${items.length}`);
     } catch (e) {
       Logger.w(TAG, `syncHistory: ${String(e)}`);
@@ -332,8 +343,14 @@ class WidgetBridgeImpl {
           cover: it.cover ? String(it.cover) : '',
         });
       }
-      const snap: LatestSnapshot = { items, updatedAt: Date.now() };
+      const store = await this.getPlayerStore();
+      const snap: LatestSnapshot = {
+        items,
+        isPlaying: store ? store.view().isPlaying : false,
+        updatedAt: Date.now(),
+      };
       await kvStore.setJSON<LatestSnapshot>(WIDGET_KV_KEYS.latest, snap);
+      await this.updateForms(WidgetKind.LATEST, snap);
       Logger.i(TAG, `syncLatest count=${items.length}`);
     } catch (e) {
       Logger.w(TAG, `syncLatest: ${String(e)}`);
@@ -429,6 +446,42 @@ class WidgetBridgeImpl {
   private async writeAndPushNowPlaying(value: NowPlayingSnapshot): Promise<void> {
     await kvStore.setJSON<NowPlayingSnapshot>(WIDGET_KV_KEYS.nowPlaying, value);
     await this.updateForms(WidgetKind.PLAYER, value);
+  }
+
+  /**
+   * The history card contains a copy of the current-player header.  Keep that
+   * copy in the same write cycle as the player card so pause/next/like updates
+   * cannot leave one card displaying stale playback state.
+   */
+  private async syncHistoryNowPlaying(nowPlaying: NowPlayingSnapshot): Promise<void> {
+    const previous = await kvStore.getJSON<HistorySnapshot>(WIDGET_KV_KEYS.history);
+    const snapshot: HistorySnapshot = {
+      nowPlaying,
+      items: previous?.items ?? [],
+      updatedAt: Date.now(),
+    };
+    await kvStore.setJSON<HistorySnapshot>(WIDGET_KV_KEYS.history, snapshot);
+    await this.updateForms(WidgetKind.HISTORY, snapshot);
+  }
+
+  /**
+   * Playlist and latest cards expose the same global play/pause control as
+   * iOS. Update their small state-only snapshots whenever playback changes
+   * instead of waiting for the next network refresh.
+   */
+  private async syncListCardPlaybackState(isPlaying: boolean): Promise<void> {
+    const playlists = await kvStore.getJSON<PlaylistsSnapshot>(WIDGET_KV_KEYS.playlists);
+    if (playlists) {
+      const snapshot: PlaylistsSnapshot = { ...playlists, isPlaying, updatedAt: Date.now() };
+      await kvStore.setJSON<PlaylistsSnapshot>(WIDGET_KV_KEYS.playlists, snapshot);
+      await this.updateForms(WidgetKind.PLAYLIST, snapshot);
+    }
+    const latest = await kvStore.getJSON<LatestSnapshot>(WIDGET_KV_KEYS.latest);
+    if (latest) {
+      const snapshot: LatestSnapshot = { ...latest, isPlaying, updatedAt: Date.now() };
+      await kvStore.setJSON<LatestSnapshot>(WIDGET_KV_KEYS.latest, snapshot);
+      await this.updateForms(WidgetKind.LATEST, snapshot);
+    }
   }
 
   /**

--- a/apps/harmony/products/entry/src/main/ets/widgets/AudioDockPlayerCard.ets
+++ b/apps/harmony/products/entry/src/main/ets/widgets/AudioDockPlayerCard.ets
@@ -8,9 +8,9 @@ import { WIDGET_COLOR, WIDGET_FONT, WIDGET_PADDING, WIDGET_RADIUS } from './Widg
  * 正在播放控制卡片（对齐 iOS AudioDockWidget）。
  *
  * 三种尺寸自适应（EntryFormAbility 在 FormBindingData 里加 formDimension 字段）：
- * - 2x2 (158x158)：封面 + 标题 + 单一播放按钮
- * - 4x2 (326x158)：封面左 + 标题/歌手右 + 三键播控
- * - 4x4 (326x326)：封面顶部 + 标题/歌手 + 三键播控 + 模式 + 点赞
+ * - 2x2：封面 + 标题 + 上一首/播放/下一首（与 iOS small 一致）
+ * - 2x4：封面左 + 标题/歌手右 + 三键播控
+ * - 4x4：居中封面 + 标题/歌手 + 模式/三键/点赞（与 iOS large 一致）
  *
  * 数据字段直接通过 @LocalStorageProp 读取主 App 推送的 NowPlayingSnapshot。
  */
@@ -48,7 +48,7 @@ struct AudioDockPlayerCard {
           this.placeholderView();
         } else if (this.formDimension === '4*4') {
           this.largeView();
-        } else if (this.formDimension === '4*2') {
+        } else if (this.formDimension === '2*4') {
           this.mediumView();
         } else {
           this.smallView();
@@ -100,8 +100,7 @@ struct AudioDockPlayerCard {
         .textOverflow({ overflow: TextOverflow.Ellipsis })
         .width('100%');
 
-      // 单个播放按钮
-      this.playButton(32, false);
+      this.transportRow(16);
     }
     .width('100%')
     .height('100%')
@@ -147,34 +146,27 @@ struct AudioDockPlayerCard {
   @Builder
   largeView() {
     Column({ space: 10 }) {
-      Row({ space: 10 }) {
-        WidgetCover({ cover: this.cover, preset: 'large' });
-        Column({ space: 4 }) {
-          Text(this.title || '—')
-            .fontSize(WIDGET_FONT.titleLarge)
-            .fontColor(WIDGET_COLOR.fg)
-            .fontWeight(FontWeight.Bold)
-            .maxLines(1)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-            .width('100%');
-          Text(this.artist || ' ')
-            .fontSize(WIDGET_FONT.artistLarge)
-            .fontColor(WIDGET_COLOR.fgSecondary)
-            .maxLines(1)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-            .width('100%');
-        }
-        .layoutWeight(1)
-        .height('100%')
-        .alignItems(HorizontalAlign.Start)
-        .justifyContent(FlexAlign.Start);
-      }
-      .width('100%');
-
-      this.transportRow(28);
-
-      Row({ space: 16 }) {
+      WidgetCover({ cover: this.cover, preset: 'xlarge' });
+      Text(this.title || '—')
+        .fontSize(WIDGET_FONT.titleLarge)
+        .fontColor(WIDGET_COLOR.fg)
+        .fontWeight(FontWeight.Bold)
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .width('100%')
+        .textAlign(TextAlign.Center);
+      Text(this.artist || ' ')
+        .fontSize(WIDGET_FONT.artistLarge)
+        .fontColor(WIDGET_COLOR.fgSecondary)
+        .maxLines(1)
+        .textOverflow({ overflow: TextOverflow.Ellipsis })
+        .width('100%')
+        .textAlign(TextAlign.Center);
+      Row({ space: 8 }) {
         this.modeButton();
+        this.iconButton('prev', 'prev', 18);
+        this.playButton(22, false);
+        this.iconButton('next', 'next', 18);
         this.likeButton();
       }
       .width('100%')
@@ -183,7 +175,7 @@ struct AudioDockPlayerCard {
     .width('100%')
     .height('100%')
     .padding(WIDGET_PADDING.card)
-    .alignItems(HorizontalAlign.Start);
+    .alignItems(HorizontalAlign.Center);
   }
 
   // ─── 公共控件 ───────────────────────────────────────────────────────────

--- a/apps/harmony/products/entry/src/main/ets/widgets/WidgetCover.ets
+++ b/apps/harmony/products/entry/src/main/ets/widgets/WidgetCover.ets
@@ -18,6 +18,7 @@ export interface CoverSize {
 }
 
 export class COVER_PRESETS {
+  static readonly xlarge: CoverSize = { width: 198, height: 198, radius: 14 };
   static readonly large: CoverSize = { width: 96, height: 96, radius: 14 };
   static readonly medium: CoverSize = { width: 64, height: 64, radius: 12 };
   static readonly small: CoverSize = { width: 40, height: 40, radius: 8 };
@@ -26,7 +27,7 @@ export class COVER_PRESETS {
 @Component
 export struct WidgetCover {
   @Prop cover: string = '';
-  @Prop preset: 'large' | 'medium' | 'small' = 'medium';
+  @Prop preset: 'xlarge' | 'large' | 'medium' | 'small' = 'medium';
 
   build() {
     Stack({ alignContent: Alignment.Center }) {
@@ -63,6 +64,7 @@ export struct WidgetCover {
   }
 
   private getSize(): CoverSize {
+    if (this.preset === 'xlarge') return COVER_PRESETS.xlarge;
     if (this.preset === 'large') return COVER_PRESETS.large;
     if (this.preset === 'small') return COVER_PRESETS.small;
     return COVER_PRESETS.medium;

--- a/apps/harmony/products/entry/src/main/resources/base/profile/form_config.json
+++ b/apps/harmony/products/entry/src/main/resources/base/profile/form_config.json
@@ -17,6 +17,7 @@
       "defaultDimension": "2*2",
       "supportDimensions": [
         "2*2",
+        "2*4",
         "4*4"
       ]
     },


### PR DESCRIPTION
### Motivation
- 修复 HarmonyOS 桌面卡片无法及时同步播放状态导致界面与 iOS 小部件不一致的问题（播放/暂停、历史、歌单、上新卡片状态不同步）。
- 保证列表类卡片（播放列表 / 上新）上的全局播放/暂停按钮能实时反映主进程的播放状态，而不是等下次网络刷新。
- 调整播放器卡片的布局与封面尺寸，使 Harmony 卡片在视觉和交互上与 iOS 小部件对齐。

### Description
- 在 `apps/harmony/products/entry/src/main/ets/models/WidgetData.ets` 中为 `PlaylistsSnapshot` 和 `LatestSnapshot` 增加了 `isPlaying` 字段以承载全局播放状态。 
- 在 `services/WidgetBridge.ets` 中：把 `syncNowPlaying` 的写入与历史、列表卡片更新合并为同一写周期，新增 `syncHistoryNowPlaying` 与 `syncListCardPlaybackState`，并在拉取歌单/历史/上新后即时调用 `updateForms` 推送到已添加的卡片。 
- 在 `formability/EntryFormAbility.ets` 中读取并暴露了 `isPlaying`，使卡片侧能正确显示列表/上新卡片的播放按钮状态。 
- 在 `widgets/AudioDockPlayerCard.ets` 中调整卡片布局与尺寸映射：支持 `2*4`（中型）尺寸、把 `2*2` small 改为上一首/播放/下一首布局，并把 large 布局调整为居中大封面与中置控件以对齐 iOS。 
- 在 `widgets/WidgetCover.ets` 中新增 `xlarge` 预设（198vp）并在播放器 large 视图中使用，以匹配 iOS large 的封面比例。 
- 在 `products/entry/src/main/resources/base/profile/form_config.json` 中为播放器卡片注册新增支持的 `2*4` 尺寸。 
- 受影响文件（主要）：`WidgetBridge.ets`、`EntryFormAbility.ets`、`WidgetData.ets`、`AudioDockPlayerCard.ets`、`WidgetCover.ets`、`form_config.json`。

### Testing
- 运行 `python3 -m json.tool apps/harmony/products/entry/src/main/resources/base/profile/form_config.json` 验证 JSON 格式，结果通过。 
- 运行 `git diff --check` 验证代码风格/冲突，结果无报错。 
- 已将修改分批 `git add` 并提交到本地分支（提交信息为 `fix(harmony): 同步桌面卡片播放状态`），提交成功。 
- 尝试通过 `gh pr create` 创建远程 PR 时因当前环境未配置 GitHub CLI 登录态而失败（提示执行 `gh auth login` 或使用 `GH_TOKEN`）；其余自动检查均通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a3d3d5dc48321bd30b1106896b432)